### PR TITLE
Add macOS Pomodoro timer example task

### DIFF
--- a/codex-cli/examples/README.md
+++ b/codex-cli/examples/README.md
@@ -41,4 +41,5 @@ Besides **camerascii**, you can experiment with:
 
 - **build‑codex‑demo**: recreate the original 2021 Codex YouTube demo.
 - **impossible‑pong**: where Codex creates more difficult levels.
+- **pomodoro‑mac**: scaffold a SwiftUI Pomodoro timer menu bar app for macOS.
 - **prompt‑analyzer**: make a data science app for clustering [prompts](https://github.com/f/awesome-chatgpt-prompts).

--- a/codex-cli/examples/pomodoro-mac/run.sh
+++ b/codex-cli/examples/pomodoro-mac/run.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# run.sh — Create a new run_N directory for a Codex task, optionally bootstrapped from a template,
+# then launch Codex with the task description from task.yaml.
+#
+# Usage:
+#   ./run.sh                  # Prompts to confirm new run
+#   ./run.sh --auto-confirm   # Skips confirmation
+#
+# Assumes:
+#   - yq and jq are installed
+#   - ../task.yaml exists (with .name and .description fields)
+#   - ../template/ exists (optional, for bootstrapping new runs)
+
+auto_mode=false
+[[ "$1" == "--auto-confirm" ]] && auto_mode=true
+
+cd runs || exit 1
+
+task_name=$(yq -o=json '.' ../task.yaml | jq -r '.name')
+echo "Checking for runs for task: $task_name"
+
+shopt -s nullglob
+run_dirs=(run_[0-9]*)
+shopt -u nullglob
+
+if [ ${#run_dirs[@]} -eq 0 ]; then
+  echo "There are 0 runs."
+  new_run_number=1
+else
+  max_run_number=0
+  for d in "${run_dirs[@]}"; do
+    if [[ "$d" =~ ^run_([0-9]+)$ ]]; then
+      if (( ${BASH_REMATCH[1]} > max_run_number )); then
+        max_run_number=${BASH_REMATCH[1]}
+      fi
+    fi
+  done
+  new_run_number=$((max_run_number + 1))
+  echo "There are $max_run_number runs."
+fi
+
+if [ "$auto_mode" = false ]; then
+  read -p "Create run_$new_run_number? (Y/N): " choice
+  if [[ "$choice" != [Yy] ]]; then
+    echo "Exiting."
+    exit 1
+  fi
+fi
+
+mkdir "run_$new_run_number"
+
+if [ -d "../template" ]; then
+  cp -r ../template/* "run_$new_run_number"
+  echo "Initialized run_$new_run_number from template/"
+else
+  echo "Template directory does not exist. Skipping initialization from template."
+fi
+
+cd "run_$new_run_number"
+
+echo "Launching..."
+description=$(yq -o=json '.' ../../task.yaml | jq -r '.description')
+codex "$description"

--- a/codex-cli/examples/pomodoro-mac/task.yaml
+++ b/codex-cli/examples/pomodoro-mac/task.yaml
@@ -1,0 +1,26 @@
+name: "pomodoro-mac"
+description: |
+  Build a polished macOS Pomodoro timer app that runs natively on Apple Silicon Macs.
+
+  Requirements:
+  - Create a SwiftUI menu bar app called "FocusBell" that shows the current session type (Focus, Short Break, Long Break) and the remaining time.
+  - Include controls to start, pause/resume, skip to the next session, and reset the cycle.
+  - Follow the classic Pomodoro structure: 25-minute focus sessions, 5-minute short breaks, and a 15-minute long break after 4 completed focus sessions.
+  - Persist timer state so the countdown survives app restarts (e.g. save to `AppStorage` or `UserDefaults`).
+  - Deliver subtle macOS notifications (via `UNUserNotificationCenter`) at the end of each session with descriptive titles and messages.
+  - Play a short system sound at session transitions using the built-in audio APIs (`NSSound` or `AudioToolbox`).
+  - Provide a preferences window that lets the user customize focus/break durations and toggle notifications/sounds. Persist preferences.
+  - Ensure the app feels native: adopt SF Symbols, respect light/dark mode, and include accessible labels.
+
+  Implementation notes:
+  - Target macOS 13+ and use Swift 5.9 or newer.
+  - Organize the project so it can be opened directly in Xcode (create an `.xcodeproj`).
+  - Structure the code cleanly with models/view models (`ObservableObject`) separated from views.
+  - Add brief inline comments explaining timer scheduling, persistence, and notification handling decisions.
+
+  Deliverables inside the run directory:
+  - The complete Xcode project with source files.
+  - A README that explains how to build/run the app, grant notification permissions, and lists the main features.
+  - (Optional) include a simple App Icon asset placeholder so the project builds without additional setup.
+
+  After scaffolding, run `xcodebuild -scheme FocusBell -configuration Release -derivedDataPath build` to ensure the project compiles.

--- a/codex-cli/examples/pomodoro-mac/template/README.md
+++ b/codex-cli/examples/pomodoro-mac/template/README.md
@@ -1,0 +1,26 @@
+# FocusBell macOS Pomodoro timer
+
+You're Codex. Use this template as guidance while building the FocusBell project.
+
+Key expectations:
+- SwiftUI menu bar app with timers and controls described in the task prompt.
+- Keep the code organized into models, view models, and views.
+- Remember to request notification permissions on first launch.
+- Persist the timer and preference state so relaunching the app restores progress.
+- Include instructions for building/running in the generated README.
+
+Suggested file layout:
+```
+FocusBell/
+├── FocusBell.xcodeproj
+├── FocusBell/
+│   ├── ContentView.swift
+│   ├── FocusBellApp.swift
+│   ├── Models/
+│   ├── ViewModels/
+│   ├── Views/
+│   └── Resources/
+└── README.md
+```
+
+Feel free to add supporting files (e.g., extensions, helpers) as needed. Strive for a native macOS polish.


### PR DESCRIPTION
## Summary
- add a pomodoro-mac example that scaffolds runs and launches Codex with a macOS SwiftUI prompt
defining the FocusBell Pomodoro timer requirements
- document the new example in the examples README alongside the helper template guidance

## Testing
- not run (non-executable changes)


------
https://chatgpt.com/codex/tasks/task_e_68e423b6b1b88325abdbd25ac4abc643